### PR TITLE
Bump bytestring

### DIFF
--- a/localize.cabal
+++ b/localize.cabal
@@ -12,7 +12,7 @@ maintainer:          portnov84@rambler.ru
 category:            Text
 build-type:          Simple
 extra-doc-files:     README.md
-cabal-version:       >=1.18
+cabal-version:       1.18
 
 library
   exposed-modules:     Text.Localize,

--- a/localize.cabal
+++ b/localize.cabal
@@ -24,7 +24,7 @@ library
   build-depends:       base > 4 && < 5,
                        mtl >= 2.2.1,
                        binary >=0.7,
-                       bytestring ==0.10.*,
+                       bytestring >= 0.10 && < 0.13,
                        text >= 1.2,
                        data-default >= 0.7,
                        containers >=0.5,


### PR DESCRIPTION
Closes #1.

Additionally correctly specifies `cabal-version`.